### PR TITLE
Add response origin, other address, change request attributes (from PR4)

### DIFF
--- a/stun_protocol/attribute.py
+++ b/stun_protocol/attribute.py
@@ -39,6 +39,7 @@ class AttributeType(IntEnum):
     RESPONSE_ORIGIN = 0x802B
     OTHER_ADDRESS = 0x802C
 
+
 def _padding_length(length: int) -> int:
     return [0, 3, 2, 1][length % 4]
 
@@ -278,25 +279,37 @@ class UserhashAttribute(LengthFixedAttributeBase):
         self._set_value(value)
 
 
-class ChangeRequestAttribute(LengthFixedAttributeBase):
-    def __init__(self, changerequest: bytes = bytes(), **kwargs):
-        super().__init__(changerequest, **kwargs)
-
-    @staticmethod
-    def fixed_length() -> int:
-        return 4
+class ChangeRequestAttribute(IntAttributeBase):
+    def __init__(self, change_request: int = 0, **kwargs):
+        super().__init__(change_request, 'I', **kwargs)
 
     @classmethod
     def attribute_type(cls: Type[Attribute]) -> AttributeType:
         return AttributeType.CHANGE_REQUEST
 
     @property
-    def changerequest(self) -> bytes:
-        return self._bytes_value
+    def change_request(self) -> int:
+        return self._int_value
 
-    @changerequest.setter
-    def changerequest(self, value: bytes) -> None:
-        self._set_value(value)
+    @change_request.setter
+    def change_request(self, value: int) -> None:
+        self._int_value = value
+
+    @property
+    def change_ip(self) -> int:
+        return self._int_value & 0x00000004
+
+    @change_ip.setter
+    def change_ip(self, value: int):
+        self._int_value |= (value & 0x00000004)
+
+    @property
+    def change_port(self) -> int:
+        return self._int_value & 0x00000002
+
+    @change_port.setter
+    def change_port(self, value: int):
+        self._int_value |= (value & 0x00000002)
 
 
 class MessageIntegrityAttribute(LengthFixedAttributeBase):

--- a/tests/test_attribute.py
+++ b/tests/test_attribute.py
@@ -478,6 +478,64 @@ class IceControllingAttributeTestCase(unittest.TestCase):
         self.assertEqual(ica.random_number, 0x1234567890ABCDEF)
 
 
+class ChangeRequestAttributeTestCase(unittest.TestCase):
+    def test_construct(self):
+        cra = attribute.ChangeRequestAttribute(0xFFFFFFF9)
+        self.assertEqual(cra.type, attribute.AttributeType.CHANGE_REQUEST)
+        self.assertEqual(cra.change_request, 0xFFFFFFF9)
+        self.assertEqual(cra.change_ip, 0x00000000)
+        self.assertEqual(cra.change_port, 0x00000000)
+
+    def test_set_change_request(self):
+        cra = attribute.ChangeRequestAttribute(0xFFFFFFF9)
+        cra.change_request = 0x12345678
+        self.assertEqual(cra.change_request, 0x12345678)
+
+    def test_set_change_ip(self):
+        cra = attribute.ChangeRequestAttribute(0xFFFFFFF9)
+        cra.change_ip = 0xFFFFFFFF
+        # self.assertEqual(cra.change_request, 0xFFFFFFFD)
+        # self.assertEqual(cra.change_ip, 0x000000004)
+        self.assertEqual(cra.change_port, 0x00000000)
+
+    def test_set_change_port(self):
+        cra = attribute.ChangeRequestAttribute(0xFFFFFFF9)
+        cra.change_port = 0xFFFFFFFF
+        self.assertEqual(cra.change_request, 0xFFFFFFFB)
+        self.assertEqual(cra.change_ip, 0x000000000)
+        self.assertEqual(cra.change_port, 0x00000002)
+
+    def test_value(self):
+        cra = attribute.ChangeRequestAttribute(0x12345678)
+        self.assertEqual(cra.value, b'\x12\x34\x56\x78')
+
+    def test_pack(self):
+        cra = attribute.ChangeRequestAttribute(0x12345678)
+        self.assertEqual(cra.pack(), b'\x00\x03\x00\x04\x12\x34\x56\x78')
+
+    def test_create(self):
+        cra = attribute.ChangeRequestAttribute.create(b'\x00\x03\x00\x04\x12\x34\x56\x79')
+        self.assertEqual(cra.change_request, 0x12345679)
+
+
+class ResponseOriginAttributeTestCase(unittest.TestCase):
+    def test_construct(self):
+        roa = attribute.ResponseOriginAttribute(1, 2, b'\x03')
+        self.assertEqual(roa.type, attribute.AttributeType.RESPONSE_ORIGIN)
+        self.assertEqual(roa.family, 1)
+        self.assertEqual(roa.port, 2)
+        self.assertEqual(roa.address, b'\x03')
+
+
+class OtherAddressAttributeTestCase(unittest.TestCase):
+    def test_construct(self):
+        oaa = attribute.OtherAddressAttribute(1, 2, b'\x03')
+        self.assertEqual(oaa.type, attribute.AttributeType.OTHER_ADDRESS)
+        self.assertEqual(oaa.family, 1)
+        self.assertEqual(oaa.port, 2)
+        self.assertEqual(oaa.address, b'\x03')
+
+
 class AttributeCreateTestCase(unittest.TestCase):
     def test_create_valid(self):
         attribute_classes = [attribute.MappedAddressAttribute,
@@ -495,7 +553,10 @@ class AttributeCreateTestCase(unittest.TestCase):
                              attribute.AlternateDomainAttribute,
                              attribute.SoftwareAttribute,
                              attribute.AlternateServerAttribute,
-                             attribute.FingerprintAttribute]
+                             attribute.FingerprintAttribute,
+                             attribute.ChangeRequestAttribute,
+                             attribute.ResponseOriginAttribute,
+                             attribute.OtherAddressAttribute]
         for cls in attribute_classes:
             a1 = cls()
             a2 = attribute.create(a1.pack())


### PR DESCRIPTION
Based on https://github.com/nbuckles13/python-stun-protocol/pull/4 from @narlim, added some unit tests and helper attributes
